### PR TITLE
Change the way the date is conveyed.

### DIFF
--- a/sponsors-en.md
+++ b/sponsors-en.md
@@ -57,7 +57,7 @@ It’s free for data scientists.
 
 # The first Data Dive is already planned
 
-It’s happening on 24./25.10.2015.
+It’s happening on October 24-25, 2015.
 
 We will help two nonprofit organisations:
 _Jambo Bukoba_ and _Streetfootballworld_.


### PR DESCRIPTION
Writing the month name out is a good way to avoid misunderstandings and makes it easier to read at glance. 
Or maybe even better `It’s happening on 2015-10-24 and 2015-10-25` ISO8601 FTW?
